### PR TITLE
fix(scraper): Fix link parsing for video titles

### DIFF
--- a/spankbang_dl/scraper.py
+++ b/spankbang_dl/scraper.py
@@ -67,10 +67,11 @@ def extract_video_info(html: str) -> tuple[str, str]:
         raise Exception("Title tag not found in HTML.")
 
     title_text: str = title_tag.get_text(strip=True)
-    if not title_text.startswith("Watch"):
-        raise Exception("Title format not recognized.")
 
     # Extract the portion between "Watch" and " -"
-    title: str = title_text.removeprefix("Watch").split(" - ")[0].strip()
+    if title_text.startswith("Watch"):
+        title: str = title_text.removeprefix("Watch").split(" - ")[0].strip()
+    else:
+        title = title_text
 
     return title, src


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->

Closes #99

## 📑 Description

<!-- Add a brief description of the pr -->

The update enhances the title parsing logic in the scraper to allow for more flexible title formats. Previously, the code raised an exception if the title did not start with "Watch". Now, it accommodates titles that do not follow this format, ensuring that links can be parsed correctly and videos can be downloaded without errors.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks

<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->

- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->

Changes were tested using the following URLs:

- https://spankbang.com/9mher/video/pov+one+day+date+with+a+sexy+doll+beautiful+legs+and+pure+mixed+race+girl
- https://spankbang.com/6p513/video/amwf+61
- https://spankbang.com/57i3y/video/porn
- https://spankbang.com/9r669/video/masseuse+rubs+me+in+all+the+right+places+maya+sinn+asandra+dewy+for+massagesins
- https://spankbang.com/9m95e/video/pov+the+sweetest+girlfriend+one+day+date+sky+lantern+blessing+romantic+record